### PR TITLE
Overlap-add convolution fix 

### DIFF
--- a/src/dartsort/util/spiketorch.py
+++ b/src/dartsort/util/spiketorch.py
@@ -302,9 +302,10 @@ def depthwise_oaconv1d(input, weight, f2=None, padding=0):
     # freq domain correlation
     f1 = torch.fft.rfft(input, n=block_size)
     if f2 is None:
-        f2 = torch.fft.rfft(weight, n=block_size)
-    # .conj() here to do cross-correlation instead of convolution (time reversal property of rfft)
-    f1.mul_(f2.conj()[:, None, :])
+        # flip direction of templates to perform cross-correlation
+        f2 = torch.fft.rfft(torch.flip(weight, (-1,)), n=block_size)
+
+    f1.mul_(f2[:, None, :])
     res = torch.fft.irfft(f1, n=block_size)
 
     # overlap add part with torch

--- a/tests/test_matching.py
+++ b/tests/test_matching.py
@@ -514,10 +514,11 @@ def test_fakedata_nonn():
     templates = np.array(
         [t[:, None] * a[None, :] for t, a in zip((t0, t1, t2, t3), amps)]
     )
-    templates[0] *= 100 / np.abs(templates[0]).max()
-    templates[1] *= 50 / np.abs(templates[0]).max()
-    templates[2] *= 100 / np.abs(templates[0]).max()
-    templates[3] *= 50 / np.abs(templates[0]).max()
+    norm = np.abs(templates[0]).max()
+    templates[0] *= 100 / norm
+    templates[1] *= 50 / norm
+    templates[2] *= 100 / norm
+    templates[3] *= 50 / norm
 
     # make fake spike trains
     spikes_per_unit = 1000


### PR DESCRIPTION
This implementation just flips the templates temporally instead of doing the conjugation. `torch.flip()` is slower than `conj` though. Need a bit of experimentation to see if we can find a better way and still match

can't get reliably closer to `torch.conv1d` than `atol=1e-5`